### PR TITLE
Fixes Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,6 @@ module.exports = function(source) {
   // Replacing custom replace syntax with webpack require call
   const regex = /'require:([^']+)'/g;
   const rootDir = this.rootContext || "..";
-  const replacement = `require('${rootDir}/$1')`;
+  const replacement = `require('${rootDir}/$1')`.replace(/\\/g, '/');
   return source.replace(regex, replacement);
 };


### PR DESCRIPTION
`this.rootContext` in Windows has path like: `C:\dir1\dir2\file.txt`.
This PR rotates those slashes by 90deg.